### PR TITLE
Update verifyCodeFmt to check java sources

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -89,13 +89,9 @@ Global / onLoad := (Global / onLoad).value.andThen { s =>
 }
 
 TaskKey[Unit]("verifyCodeFmt") := {
-  scalafmtCheckAll.all(ScopeFilter(inAnyProject)).result.value.toEither.left.foreach { _ =>
+  javafmtCheckAll.all(ScopeFilter(inAnyProject)).result.value.toEither.left.foreach { _ =>
     throw new MessageOnlyException(
-      "Unformatted Scala code found. Please run 'scalafmtAll' and commit the reformatted code")
-  }
-  (Compile / scalafmtSbtCheck).result.value.toEither.left.foreach { _ =>
-    throw new MessageOnlyException(
-      "Unformatted sbt code found. Please run 'scalafmtSbt' and commit the reformatted code")
+      "Unformatted Java code found. Please run 'javafmtAll' and commit the reformatted code")
   }
 }
 


### PR DESCRIPTION
Replaces the current `verifyCodeFmt` implement which checks for Scala sources to one that checks for Java sources. Note that the Scala sources implementation is pointless here because we already have a github workflow check that checks for Scala sources.