### PR TITLE
Remove deprecated multiarg infix tuple syntax

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalTables.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalTables.scala
@@ -74,7 +74,7 @@ trait JournalTables {
         eventSerManifest,
         metaPayload,
         metaSerId,
-        metaSerManifest) <> (JournalPekkoSerializationRow.tupled, JournalPekkoSerializationRow.unapply)
+        metaSerManifest).<>(JournalPekkoSerializationRow.tupled, JournalPekkoSerializationRow.unapply)
 
     val ordering: Rep[Long] = column[Long](journalTableCfg.columnNames.ordering, O.AutoInc)
     val persistenceId: Rep[String] =
@@ -101,7 +101,7 @@ trait JournalTables {
   lazy val JournalTable = new TableQuery(tag => new JournalEvents(tag))
 
   class EventTags(_tableTag: Tag) extends Table[TagRow](_tableTag, tagTableCfg.schemaName, tagTableCfg.tableName) {
-    override def * = (eventId, tag) <> (TagRow.tupled, TagRow.unapply)
+    override def * = (eventId, tag).<>(TagRow.tupled, TagRow.unapply)
 
     val eventId: Rep[Long] = column[Long](tagTableCfg.columnNames.eventId)
     val tag: Rep[String] = column[String](tagTableCfg.columnNames.tag)

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/JournalTables.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/JournalTables.scala
@@ -28,7 +28,7 @@ trait JournalTables {
         _tableTag,
         _schemaName = journalTableCfg.schemaName,
         _tableName = journalTableCfg.tableName) {
-    def * = (ordering, deleted, persistenceId, sequenceNumber, message, tags) <> (JournalRow.tupled, JournalRow.unapply)
+    def * = (ordering, deleted, persistenceId, sequenceNumber, message, tags).<>(JournalRow.tupled, JournalRow.unapply)
 
     val ordering: Rep[Long] = column[Long](journalTableCfg.columnNames.ordering, O.AutoInc)
     val persistenceId: Rep[String] =

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/snapshot/dao/SnapshotTables.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/snapshot/dao/SnapshotTables.scala
@@ -53,7 +53,7 @@ trait SnapshotTables {
         snapshotPayload,
         metaSerId,
         metaSerManifest,
-        metaPayload) <> (SnapshotRow.tupled, SnapshotRow.unapply)
+        metaPayload).<>(SnapshotRow.tupled, SnapshotRow.unapply)
 
     val persistenceId: Rep[String] =
       column[String](snapshotTableCfg.columnNames.persistenceId, O.Length(255, varying = true))

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/snapshot/dao/legacy/SnapshotTables.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/snapshot/dao/legacy/SnapshotTables.scala
@@ -41,7 +41,7 @@ trait SnapshotTables {
         _tableTag,
         _schemaName = snapshotTableCfg.schemaName,
         _tableName = snapshotTableCfg.tableName) {
-    def * = (persistenceId, sequenceNumber, created, snapshot) <> (SnapshotRow.tupled, SnapshotRow.unapply)
+    def * = (persistenceId, sequenceNumber, created, snapshot).<>(SnapshotRow.tupled, SnapshotRow.unapply)
 
     val persistenceId: Rep[String] =
       column[String](snapshotTableCfg.columnNames.persistenceId, O.Length(255, varying = true))


### PR DESCRIPTION
This PR removes this use of deprecated syntax, i.e.

```
[warn] /Users/mdedetrich/github/incubator-pekko-persistence-jdbc/core/src/main/scala/org/apache/pekko/persistence/jdbc/snapshot/dao/SnapshotTables.scala:56:22: multiarg infix syntax looks like a tuple and will be deprecated
[warn]         metaPayload) <> (SnapshotRow.tupled, SnapshotRow.unapply)
```

We would have likely had to do this anyways because in Scala 3 this code wouldn't even compile