### PR TITLE
Add Scala 3 support

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -66,9 +66,9 @@ jobs:
       - name: Cache Coursier cache
         uses: coursier/cache-action@v6
 
-      - name: Compile all code with fatal warnings for Java 11, Scala 2.12 and Scala 2.13
+      - name: Compile all code with fatal warnings for Java 11, Scala 2.12, Scala 2.13 and Scala 3
         # Run locally with: sbt 'clean ; +Test/compile ; +It/compile'
-        run: sbt "; Test/compile; It/compile"
+        run: sbt "; +Test/compile; +It/compile"
 
   check-docs:
     name: Check Docs

--- a/.github/workflows/h2-test.yml
+++ b/.github/workflows/h2-test.yml
@@ -19,9 +19,11 @@ jobs:
       matrix:
         include:
           - { java-version: 8,  scala-version: 2.12, sbt-opts: '' }
-          - { java-version: 8,  scala-version: 2.13,  sbt-opts: '' }
+          - { java-version: 8,  scala-version: 2.13, sbt-opts: '' }
+          - { java-version: 8,  scala-version: 3.3,  sbt-opts: '' }
           - { java-version: 11, scala-version: 2.12, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
-          - { java-version: 11, scala-version: 2.13,  sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { java-version: 11, scala-version: 2.13, sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
+          - { java-version: 11, scala-version: 3.3,  sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
     steps:
       - name: Checkout
         uses: actions/checkout@v4

--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -3,6 +3,8 @@ pullRequests.frequency = "@monthly"
 updates.ignore = [
   // explicit updates
   { groupId = "com.typesafe.akka" }
+  # Pin logback to v1.3.x because v1.4.x needs JDK11
+  { groupId = "ch.qos.logback", version="1.3." }
 ]
 
 commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"

--- a/core/src/main/mima-filters/1.1.x.backwards.excludes/slick-3.3-to-3.5.backwards.excludes
+++ b/core/src/main/mima-filters/1.1.x.backwards.excludes/slick-3.3-to-3.5.backwards.excludes
@@ -1,0 +1,53 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+ProblemFilters.exclude[IncompatibleSignatureProblem]("org.apache.pekko.persistence.jdbc.db.EagerSlickDatabase.unapply")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.jdbc.db.EagerSlickDatabase.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("org.apache.pekko.persistence.jdbc.db.EagerSlickDatabase.tupled")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("org.apache.pekko.persistence.jdbc.db.EagerSlickDatabase.curried")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.persistence.jdbc.db.EagerSlickDatabase.database")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.jdbc.db.EagerSlickDatabase.copy")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.persistence.jdbc.db.EagerSlickDatabase.copy$default$1")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.jdbc.db.EagerSlickDatabase.this")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.jdbc.db.EagerSlickDatabase.apply")
+ProblemFilters.exclude[IncompatibleSignatureProblem]("org.apache.pekko.persistence.jdbc.db.EagerSlickDatabase.unapply")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.persistence.jdbc.db.LazySlickDatabase.database")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.persistence.jdbc.db.SlickDatabase.forConfig")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.persistence.jdbc.db.SlickDatabase.database")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.persistence.jdbc.db.SlickDatabase.database")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.persistence.jdbc.db.SlickDatabase.forConfig")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.persistence.jdbc.journal.JdbcAsyncWriteJournal.db")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.persistence.jdbc.journal.dao.DefaultJournalDao.db")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.jdbc.journal.dao.DefaultJournalDao.this")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.persistence.jdbc.journal.dao.legacy.BaseByteArrayJournalDao.db")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.persistence.jdbc.journal.dao.legacy.BaseByteArrayJournalDao.db")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.persistence.jdbc.journal.dao.legacy.ByteArrayJournalDao.db")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.jdbc.journal.dao.legacy.ByteArrayJournalDao.this")
+ProblemFilters.exclude[MissingTypesProblem]("org.apache.pekko.persistence.jdbc.journal.dao.legacy.package$JournalRow$")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.persistence.jdbc.query.dao.DefaultReadJournalDao.db")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.jdbc.query.dao.DefaultReadJournalDao.this")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.persistence.jdbc.query.dao.legacy.BaseByteArrayReadJournalDao.db")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.persistence.jdbc.query.dao.legacy.BaseByteArrayReadJournalDao.db")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.persistence.jdbc.query.dao.legacy.ByteArrayReadJournalDao.db")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.jdbc.query.dao.legacy.ByteArrayReadJournalDao.this")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.persistence.jdbc.query.dao.legacy.OracleReadJournalDao.db")
+ProblemFilters.exclude[ReversedMissingMethodProblem]("org.apache.pekko.persistence.jdbc.query.dao.legacy.OracleReadJournalDao.db")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.persistence.jdbc.snapshot.JdbcSnapshotStore.db")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.jdbc.snapshot.dao.DefaultSnapshotDao.this")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.jdbc.snapshot.dao.legacy.ByteArraySnapshotDao.this")
+ProblemFilters.exclude[IncompatibleResultTypeProblem]("org.apache.pekko.persistence.jdbc.state.JdbcDurableStateStoreProvider.db")
+ProblemFilters.exclude[IncompatibleMethTypeProblem]("org.apache.pekko.persistence.jdbc.state.scaladsl.JdbcDurableStateStore.this")

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -18,6 +18,8 @@ object Dependencies {
 
   val PekkoVersion = PekkoCoreDependency.version
 
+  val LogbackVersion = "1.3.14"
+
   val SlickVersion = "3.5.0"
   val ScalaTestVersion = "3.2.18"
 
@@ -32,7 +34,7 @@ object Dependencies {
     "org.apache.pekko" %% "pekko-persistence-query" % PekkoVersion,
     "com.typesafe.slick" %% "slick" % SlickVersion,
     "com.typesafe.slick" %% "slick-hikaricp" % SlickVersion,
-    "ch.qos.logback" % "logback-classic" % "1.2.13" % Test,
+    "ch.qos.logback" % "logback-classic" % LogbackVersion % Test,
     "org.apache.pekko" %% "pekko-slf4j" % PekkoVersion % Test,
     "org.apache.pekko" %% "pekko-persistence-tck" % PekkoVersion % Test,
     "org.apache.pekko" %% "pekko-stream-testkit" % PekkoVersion % Test,
@@ -41,7 +43,7 @@ object Dependencies {
 
   val Migration: Seq[ModuleID] = Seq(
     "com.typesafe" % "config" % "1.4.3",
-    "ch.qos.logback" % "logback-classic" % "1.2.13",
+    "ch.qos.logback" % "logback-classic" % LogbackVersion,
     "org.testcontainers" % "postgresql" % "1.16.3" % Test,
     "org.scalatest" %% "scalatest" % ScalaTestVersion % Test) ++ JdbcDrivers.map(_ % Provided)
 }

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,11 +13,12 @@ object Dependencies {
   // Keep in sync with .github CI build
   val Scala212 = "2.12.18"
   val Scala213 = "2.13.12"
-  val ScalaVersions = Seq(Scala212, Scala213)
+  val Scala3 = "3.3.3"
+  val ScalaVersions = Seq(Scala212, Scala213, Scala3)
 
   val PekkoVersion = PekkoCoreDependency.version
 
-  val SlickVersion = "3.3.3"
+  val SlickVersion = "3.5.0"
   val ScalaTestVersion = "3.2.18"
 
   val JdbcDrivers = Seq(


### PR DESCRIPTION
Adds Scala 3 support while updating to Slick 3.5.0

Resolves: https://github.com/apache/incubator-pekko-persistence-jdbc/issues/43