### PR TITLE
Unwrap single string interpolation syntax

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/state/DurableStateQueries.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/state/DurableStateQueries.scala
@@ -71,7 +71,7 @@ import pekko.persistence.jdbc.config.DurableStateTableConfiguration
             VALUES
             (
               ${row.persistenceId},
-              #${seqNextValue},
+              #$seqNextValue,
               ${row.revision},
               ${row.statePayload},
               ${row.stateSerId},
@@ -84,7 +84,7 @@ import pekko.persistence.jdbc.config.DurableStateTableConfiguration
 
   private[jdbc] def updateDbWithDurableState(row: DurableStateTables.DurableStateRow, seqNextValue: String) = {
     sqlu"""UPDATE #${durableStateTableCfg.tableName}
-           SET #${durableStateTableCfg.columnNames.globalOffset} = #${seqNextValue},
+           SET #${durableStateTableCfg.columnNames.globalOffset} = #$seqNextValue,
                #${durableStateTableCfg.columnNames.revision} = ${row.revision},
                #${durableStateTableCfg.columnNames.statePayload} = ${row.statePayload},
                #${durableStateTableCfg.columnNames.stateSerId} = ${row.stateSerId},

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/query/JournalDaoStreamMessagesMemoryTest.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/query/JournalDaoStreamMessagesMemoryTest.scala
@@ -123,7 +123,7 @@ abstract class JournalDaoStreamMessagesMemoryTest(configFile: String)
             .map {
               case Success((repr, _)) =>
                 if (repr.sequenceNr % 100 == 0)
-                  log.info(s"fetched: ${repr.persistenceId} - ${repr.sequenceNr}/${totalMessages}")
+                  log.info(s"fetched: ${repr.persistenceId} - ${repr.sequenceNr}/$totalMessages")
               case Failure(exception) =>
                 log.error("Failure when reading messages.", exception)
             }

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/query/QueryTestSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/query/QueryTestSpec.scala
@@ -409,7 +409,7 @@ trait SqlServerCleaner extends QueryTestSpec {
     }
     withStatement { stmt =>
       tables.foreach { name => stmt.executeUpdate(s"DELETE FROM $name") }
-      stmt.executeUpdate(s"DBCC CHECKIDENT('${journalTableName}', RESEED, $reset)")
+      stmt.executeUpdate(s"DBCC CHECKIDENT('$journalTableName', RESEED, $reset)")
     }
   }
 

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/Payloads.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/Payloads.scala
@@ -25,13 +25,13 @@ class MyPayloadSerializer extends Serializer {
   def includeManifest: Boolean = true
 
   def toBinary(o: AnyRef): Array[Byte] = o match {
-    case MyPayload(data) => s"${data}".getBytes("UTF-8")
+    case MyPayload(data) => s"$data".getBytes("UTF-8")
     case _               => throw new Exception("Unknown object for serialization")
   }
 
   def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = manifest match {
     case Some(MyPayloadClass) => MyPayload(s"${new String(bytes, "UTF-8")}")
-    case Some(c)              => throw new Exception(s"unexpected manifest ${c}")
+    case Some(c)              => throw new Exception(s"unexpected manifest $c")
     case None                 => throw new Exception("no manifest")
   }
 }

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -69,7 +69,7 @@ trait CopyrightHeader extends AutoPlugin {
         case Some(currentText) if isLightbendCopyrighted(currentText) =>
           HeaderCommentStyle.cStyleBlockComment.commentCreator(text, existingText) + NewLine * 2 + currentText
         case Some(currentText) =>
-          throw new IllegalStateException(s"Unable to detect copyright for header:[${currentText}]")
+          throw new IllegalStateException(s"Unable to detect copyright for header:[$currentText]")
         case None =>
           HeaderCommentStyle.cStyleBlockComment.commentCreator(text, existingText)
       }


### PR DESCRIPTION
Unwraps single string interpolation i.e. `s"${something}"` into `s"$something"`. Make sure to do a rebase merge of this PR because I need to add its commit to `.git-blame-ignore-revs`