### PR TITLE
Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,5 @@
+# scalafmt
+c69b4062b3530798e43287cc75a74ade11955b53
+
+# manual
+a48ac56bd5da81c39c12e6aeb67d5fa14f8f3593

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -50,6 +50,16 @@ Which licenses are compatible with Apache 2 are defined in [this doc](https://ww
 
 > Each license in this category requires some degree of [reciprocity](https://www.apache.org/legal/3party.html#define-reciprocal); therefore, additional action must be taken in order to minimize the chance that a user of an Apache product will create a derivative work of a reciprocally-licensed portion of an Apache product without being aware of the applicable requirements.
 
+### Ignoring formatting commits in git blame
+
+Throughout the history of the codebase various formatting commits have been applied as the scalafmt style has evolved over time, if desired
+one can setup git blame to ignore these commits. The hashes for these specific are stored in [this file](.git-blame-ignore-revs) so to configure
+git blame to ignore these commits you can execute the following.
+
+```shell
+git config blame.ignoreRevsFile .git-blame-ignore-revs
+```
+
 ## Creating Commits And Writing Commit Messages
 
 Follow these guidelines when creating public commits and writing commit messages.


### PR DESCRIPTION
The project didn't have it in the first place. Added https://github.com/apache/incubator-pekko-persistence-jdbc/pull/46 and https://github.com/apache/incubator-pekko-persistence-jdbc/pull/3 to `.git-blame-ignore-revs` and also documented `CONTRIBUTING.md`.