### PR TITLE
Use proper type for SemVerSpec

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ import sbt.Keys._
 ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
 
 ThisBuild / apacheSonatypeProjectProfile := "pekko"
-ThisBuild / versionScheme := Some("semver-spec")
+ThisBuild / versionScheme := Some(VersionScheme.SemVerSpec)
 sourceDistName := "incubating-pekko-persistence-jdbc"
 
 lazy val `pekko-persistence-jdbc` = project


### PR DESCRIPTION
There is an actual proper type for `SemVerSpec` which is better than using a `String`.