### PR TITLE
Cache snapshots to prevent overloading Apache Nexus repo

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,9 @@ import com.lightbend.paradox.apidoc.ApidocPlugin.autoImport.apidocRootPackage
 import org.apache.pekko.PekkoParadoxPlugin.autoImport._
 import sbt.Keys._
 
+// TODO: Remove when Pekko has a proper release
 ThisBuild / resolvers += Resolver.ApacheMavenSnapshotsRepo
+ThisBuild / updateOptions := updateOptions.value.withLatestSnapshots(false)
 
 ThisBuild / apacheSonatypeProjectProfile := "pekko"
 ThisBuild / versionScheme := Some(VersionScheme.SemVerSpec)

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,5 @@
 resolvers += Resolver.ApacheMavenSnapshotsRepo
+updateOptions := updateOptions.value.withLatestSnapshots(false)
 
 // compliance
 addSbtPlugin("de.heikoseeberger" % "sbt-header" % "5.7.0")


### PR DESCRIPTION
The Apache Snapshots nexus repo is sometimes giving us request refused, likely because we are overloading the repo with excessive amount of requests.  This is due to the fact that we are using `SNAPSHOT` versions which by default don't cache because they are mutable (i.e. you can reupload snapshots with different implementations as much as you like).

Since for both pekko and its project forks the snapshot version is derived from git hash, there is no disadvantage to caching the snapshot.