### PR TITLE
Updated documentation to call out Durable State restrictions

### DIFF
--- a/core/src/test/resources/h2-application.conf
+++ b/core/src/test/resources/h2-application.conf
@@ -27,6 +27,9 @@ pekko {
       // Enable the line below to automatically start the snapshot-store when the actorsystem is started
       // auto-start-snapshot-stores = ["jdbc-snapshot-store"]
     }
+    state {
+      plugin = "jdbc-durable-state-store"
+    }
   }
 }
 

--- a/core/src/test/resources/h2-shared-db-application.conf
+++ b/core/src/test/resources/h2-shared-db-application.conf
@@ -26,6 +26,9 @@ pekko {
       // Enable the line below to automatically start the snapshot-store when the actorsystem is started
       // auto-start-snapshot-stores = ["jdbc-snapshot-store"]
     }
+    state {
+      plugin = "jdbc-durable-state-store"
+    }
   }
 }
 

--- a/core/src/test/resources/postgres-application.conf
+++ b/core/src/test/resources/postgres-application.conf
@@ -27,6 +27,9 @@ pekko {
       // Enable the line below to automatically start the snapshot-store when the actorsystem is started
       // auto-start-snapshot-stores = ["jdbc-snapshot-store"]
     }
+    state {
+      plugin = "jdbc-durable-state-store"
+    }
   }
 }
 

--- a/core/src/test/resources/postgres-shared-db-application.conf
+++ b/core/src/test/resources/postgres-shared-db-application.conf
@@ -26,6 +26,9 @@ pekko {
       // Enable the line below to automatically start the snapshot-store when the actorsystem is started
       // auto-start-snapshot-stores = ["jdbc-snapshot-store"]
     }
+    state {
+      plugin = "jdbc-durable-state-store"
+    }
   }
 }
 

--- a/docs/src/main/paradox/configuration.md
+++ b/docs/src/main/paradox/configuration.md
@@ -6,6 +6,7 @@ Configure `pekko-persistence`:
 
 - instruct Apache Pekko persistence to use the `jdbc-journal` plugin,
 - instruct Apache Pekko persistence to use the `jdbc-snapshot-store` plugin,
+- instruct Apache Pekko persistence to use the `jdbc-durable-state-store` plugin (Postgres and H2 only)
 
 Configure `slick`:
 

--- a/docs/src/main/paradox/overview.md
+++ b/docs/src/main/paradox/overview.md
@@ -2,7 +2,7 @@
 
 The Apache Pekko Persistence JDBC plugin allows for using JDBC-compliant databases as backend for @extref:[Apache Pekko Persistence](pekko:persistence.html) and @extref:[Apache Pekko Persistence Query](pekko:persistence-query.html).
 
-pekko-persistence-jdbc writes journal and snapshot entries to a configured JDBC store. It implements the full pekko-persistence-query API and is therefore very useful for implementing DDD-style application models using Apache Pekko and Scala for creating reactive applications.
+pekko-persistence-jdbc writes journal and snapshot entries to a configured JDBC store. It implements the full pekko-persistence-query API and is therefore very useful for implementing DDD-style application models using Apache Pekko and Scala for creating reactive applications. It also supports Durable State, although only when using a Postgres or H2 backend.
 
 Apache Pekko Persistence JDBC requires Apache Pekko $pekko.version$ or later. It uses @extref:[Slick](slick:) $slick.version$ internally to access the database via JDBC, this does not require user code to make use of Slick.
 


### PR DESCRIPTION
Durable State is currently only available for H2 and Postgres databases, but the documentation makes no mention of this. This leads to runtime errors if trying to use an unsupported database.
Related to but does not close https://github.com/apache/incubator-pekko-persistence-jdbc/issues/56