### PR TITLE
Split MissingElements into its own public class

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/MissingElements.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/MissingElements.scala
@@ -1,0 +1,38 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * license agreements; and to You under the Apache License, version 2.0:
+ *
+ *   https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * This file is part of the Apache Pekko project, which was derived from Akka.
+ */
+
+package org.apache.pekko.persistence.jdbc
+
+import scala.collection.immutable.NumericRange
+
+/**
+ * Efficient representation of missing elements using NumericRanges.
+ * It can be seen as a collection of OrderingIds
+ */
+final case class MissingElements[A](elements: Seq[NumericRange[A]])(implicit num: Integral[A]) {
+  def addRange(from: A, until: A): MissingElements[A] = {
+    val newRange = NumericRange(from, until, num.one)
+    MissingElements(elements :+ newRange)
+  }
+  def contains(id: A): Boolean = elements.exists(_.containsTyped(id))
+  def isEmpty: Boolean = elements.forall(_.isEmpty)
+  def size: Int = elements.map(_.size).sum
+  override def toString: String = {
+    elements
+      .collect {
+        case range if range.nonEmpty =>
+          if (range.size == 1) range.start.toString
+          else s"${range.start}-${range.end}"
+      }
+      .mkString(", ")
+  }
+}
+object MissingElements {
+  def empty[A: Integral]: MissingElements[A] = MissingElements(Vector.empty)
+}


### PR DESCRIPTION
This PR is a reaction to https://github.com/apache/incubator-pekko-persistence-jdbc/pull/44#discussion_r1257967998 (i.e. Scala 3 is refusing to compile this code because it detects `MissingElements` being used in a public setting, i.e. `receive`/`findGaps` is a public method asks for `MissingElements` in a parameter however `MissingElements` defined as private, I have no idea how Scala 2 managed to compile this as its impossible to call these methods outside of the scope of private but its fixed in Scala 3). Ontop of this I noticed that `MissingElements` is duplicated with the exact same implementation in multiple places.

What this PR does is it moves `MissingElements` into its own public class that is abstracted over an `Integral` number (which means that when you instantiate `MissingElements` you provide one of the `Integral` types i.e. `Long`/`Int`) and then modifies `JournalSequenceActor`/`DurableStateSequenceActor` to use this new type.