### PR TITLE
Use fetch tags from latest checkout action

### DIFF
--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -16,10 +16,11 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Checkout GitHub merge
         if: github.event.pull_request
@@ -45,9 +46,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Checkout GitHub merge
         if: github.event.pull_request
@@ -73,9 +75,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Checkout GitHub merge
         if: github.event.pull_request

--- a/.github/workflows/format.yml
+++ b/.github/workflows/format.yml
@@ -13,9 +13,10 @@ jobs:
     if: github.repository == 'apache/incubator-pekko-persistence-jdbc'
     steps:
       - name: Checkout current branch (full)
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
           persist-credentials: false
 
       - name: Check project is formatted

--- a/.github/workflows/h2-test.yml
+++ b/.github/workflows/h2-test.yml
@@ -24,9 +24,10 @@ jobs:
           - { java-version: 11, scala-version: 2.13.11,  sbt-opts: '-J-XX:+UnlockExperimentalVMOptions -J-XX:+UseJVMCICompiler' }
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Checkout GitHub merge
         if: github.event.pull_request

--- a/.github/workflows/headers.yml
+++ b/.github/workflows/headers.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Setup Java 11
         uses: actions/setup-java@v3

--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -12,15 +12,10 @@ jobs:
     runs-on: ubuntu-20.04
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
-          # See https://github.com/actions/checkout/issues/299#issuecomment-677674415
-          ref: ${{ github.event.pull_request.head.sha }}
-          fetch-depth: 100
-
-      # temporarily disable tag fetch (there are no tags right now and this then fails)
-      # - name: Fetch tags
-      #  run: git fetch --depth=100 origin +refs/tags/*:refs/tags/*
+          fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Java 11
         uses: actions/setup-java@v3

--- a/.github/workflows/mysql-tests.yml
+++ b/.github/workflows/mysql-tests.yml
@@ -23,9 +23,10 @@ jobs:
           
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Checkout GitHub merge
         if: github.event.pull_request

--- a/.github/workflows/oracle-tests.yml
+++ b/.github/workflows/oracle-tests.yml
@@ -23,9 +23,10 @@ jobs:
           
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Checkout GitHub merge
         if: github.event.pull_request

--- a/.github/workflows/postgres-tests.yml
+++ b/.github/workflows/postgres-tests.yml
@@ -23,9 +23,10 @@ jobs:
           
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Checkout GitHub merge
         if: github.event.pull_request

--- a/.github/workflows/publish-1.0-docs.yml
+++ b/.github/workflows/publish-1.0-docs.yml
@@ -16,10 +16,11 @@ jobs:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Java 8
         uses: actions/setup-java@v3

--- a/.github/workflows/publish-nightly.yml
+++ b/.github/workflows/publish-nightly.yml
@@ -18,10 +18,11 @@ jobs:
       JAVA_OPTS: -Xms2G -Xmx2G -Xss2M -XX:ReservedCodeCacheSize=256M -Dfile.encoding=UTF-8
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           # we don't know what commit the last tag was it's safer to get entire repo so previousStableVersion resolves
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Setup Java 8
         uses: actions/setup-java@v3

--- a/.github/workflows/sqlserver-tests.yml
+++ b/.github/workflows/sqlserver-tests.yml
@@ -23,9 +23,10 @@ jobs:
           
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
+          fetch-tags: true
 
       - name: Checkout GitHub merge
         if: github.event.pull_request


### PR DESCRIPTION
The latest version of the checkout github actions now supports a `fetch-tags` flag which does as described, i.e. it will fetch all of our tags which removes the various workarounds that was used before (i.e. manually running `git fetch` command) etc etc, see https://github.com/actions/checkout/pull/579

This will also help in the erroneous errors that we get in CI, i.e. 

```
[error] Failed to derive version from git tags. Maybe run `git fetch --unshallow` or `git fetch upstream` on a fresh git clone from a fork? Derived version: 0.0.0+1-337943bd-SNAPSHOT`
```