### PR TITLE
Rework filter clause before join on eventsByTag

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/dao/ReadJournalQueries.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/dao/ReadJournalQueries.scala
@@ -60,10 +60,10 @@ class ReadJournalQueries(val profile: JdbcProfile, val readJournalConfig: ReadJo
       max: ConstColumn[Long]) = {
     baseTableQuery()
       .filter(row => row.ordering > offset && row.ordering <= maxOffset)
-      .sortBy(_.ordering.asc)
       .join(TagTable)
       .on(_.ordering === _.eventId)
       .filter(_._2.tag === tag)
+      .sortBy(_._1.ordering.asc)
       .take(max)
       .map(_._1)
   }


### PR DESCRIPTION
Original issue
https://github.com/apache/incubator-pekko-persistence-jdbc/issues/105

The event-journal join to event-tag is happening before the offset/ordering where clause.

The subquery is therefore returning the entire event-journal when getting eventsByTag.
The filter for ordering only pertains to the event-journal. By moving that into the subquery where clause it will not return the entire event-journal each time eventsByTag is called.