### PR TITLE
Fix -skip-packages scaladoc for Scala 3

### DIFF
--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -72,10 +72,12 @@ object ProjectAutoPlugin extends AutoPlugin {
       "-doc-version",
       version.value,
       "-sourcepath",
-      (ThisBuild / baseDirectory).value.toString,
-      "-skip-packages",
-      "pekko.pattern", // for some reason Scaladoc creates this
-      "-doc-source-url", {
+      (ThisBuild / baseDirectory).value.toString) ++ {
+      if (scalaBinaryVersion.value == "3")
+        List("-skip-packages:pekko.pattern")
+      else
+        List("-skip-packages", "pekko.pattern")
+    } ++ List("-doc-source-url", {
         val branch = if (isSnapshot.value) "master" else s"v${version.value}"
         s"https://github.com/apache/incubator-pekko-persistence-jdbc/tree/${branch}€{FILE_PATH_EXT}#L€{FILE_LINE}"
       },


### PR DESCRIPTION
Resolves: https://github.com/apache/incubator-pekko-persistence-jdbc/issues/124

I can confirm that it works by running `sbt "+compile:doc"` locally (without this change the command fails and with this change the command passes fine).

Also some logic used in [pekko-http](https://github.com/apache/incubator-pekko-http/blob/6df57df1c46c0d3b90cca2bd21ad107ced354043/project/Doc.scala#L78-L82)