### PR TITLE
Use standard commit message for scala-steward

### DIFF
--- a/.scala-steward.conf
+++ b/.scala-steward.conf
@@ -7,6 +7,4 @@ updates.ignore = [
   { groupId = "ch.qos.logback", version="1.3." }
 ]
 
-commits.message = "${artifactName} ${nextVersion} (was ${currentVersion})"
-
 updatePullRequests = never


### PR DESCRIPTION
While this may be nicer, its different from the rest of the projects so we should use the default message for now