### PR TITLE
limit windowing support snapshoted events

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/BaseJournalDaoWithReadMessages.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/BaseJournalDaoWithReadMessages.scala
@@ -51,12 +51,12 @@ trait BaseJournalDaoWithReadMessages extends JournalDaoWithReadMessages {
       toSequenceNr: Long,
       batchSize: Int,
       refreshInterval: Option[(FiniteDuration, Scheduler)]) = {
-    val firstSequenceVer: Long = Math.max(1, fromSequenceNr)
+    val firstSequenceNr: Long = Math.max(1, fromSequenceNr)
     Source
-      .unfoldAsync[(Long, FlowControl), Seq[Try[(PersistentRepr, Long)]]]((firstSequenceVer, Continue)) {
+      .unfoldAsync[(Long, FlowControl), Seq[Try[(PersistentRepr, Long)]]]((firstSequenceNr, Continue)) {
         case (from, control) =>
           def limitWindow(from: Long): Long = {
-            if (from == firstSequenceVer || batchSize <= 0 || (Long.MaxValue - batchSize) < from) {
+            if (from == firstSequenceNr || batchSize <= 0 || (Long.MaxValue - batchSize) < from) {
               toSequenceNr
             } else {
               Math.min(from + batchSize, toSequenceNr)

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/BaseJournalDaoWithReadMessages.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/BaseJournalDaoWithReadMessages.scala
@@ -19,7 +19,7 @@ import pekko.NotUsed
 import pekko.actor.Scheduler
 import pekko.annotation.InternalApi
 import pekko.persistence.PersistentRepr
-import pekko.persistence.jdbc.journal.dao.FlowControl.{ Continue, ContinueDelayed, Stop }
+import pekko.persistence.jdbc.journal.dao.FlowControl.{ Continue, ContinueDelayed, Fallback, Stop }
 import pekko.stream.Materializer
 import pekko.stream.scaladsl.{ Sink, Source }
 
@@ -51,22 +51,24 @@ trait BaseJournalDaoWithReadMessages extends JournalDaoWithReadMessages {
       toSequenceNr: Long,
       batchSize: Int,
       refreshInterval: Option[(FiniteDuration, Scheduler)]) = {
-    val initializedQueryState: Long = Math.max(1, fromSequenceNr)
+    val firstSequenceVer: Long = Math.max(1, fromSequenceNr)
     Source
-      .unfoldAsync[(Long, FlowControl), Seq[Try[(PersistentRepr, Long)]]]((initializedQueryState, Continue)) {
+      .unfoldAsync[(Long, FlowControl), Seq[Try[(PersistentRepr, Long)]]]((firstSequenceVer, Continue)) {
         case (from, control) =>
-          def limitWindow(from: Long): Long = {
-            if (batchSize <= 0 || (Long.MaxValue - batchSize) < from) {
+          def limitWindow(from: Long)(implicit fallback: Boolean): Long = {
+            if (fallback || batchSize <= 0 || (Long.MaxValue - batchSize) < from) {
               toSequenceNr
             } else {
               Math.min(from + batchSize, toSequenceNr)
             }
           }
 
-          def retrieveNextBatch(): Future[Option[((Long, FlowControl), Seq[Try[(PersistentRepr, Long)]])]] = {
+          def retrieveNextBatch(implicit fallback: Boolean = false)
+              : Future[Option[((Long, FlowControl), Seq[Try[(PersistentRepr, Long)]])]] = {
             for {
               xs <- messages(persistenceId, from, limitWindow(from), batchSize).runWith(Sink.seq)
             } yield {
+              val isEmptyEvents = xs.isEmpty
               val hasMoreEvents = xs.size == batchSize
               // Events are ordered by sequence number, therefore the last one is the largest)
               val lastSeqNrInBatch: Option[Long] = xs.lastOption match {
@@ -78,6 +80,7 @@ trait BaseJournalDaoWithReadMessages extends JournalDaoWithReadMessages {
               val nextControl: FlowControl =
                 if (hasLastEvent || from > toSequenceNr) Stop
                 else if (hasMoreEvents) Continue
+                else if (isEmptyEvents && from == firstSequenceVer) Fallback
                 else if (refreshInterval.isEmpty) Stop
                 else ContinueDelayed
 
@@ -96,6 +99,7 @@ trait BaseJournalDaoWithReadMessages extends JournalDaoWithReadMessages {
             case ContinueDelayed =>
               val (delay, scheduler) = refreshInterval.get
               pekko.pattern.after(delay, scheduler)(retrieveNextBatch())
+            case Fallback => retrieveNextBatch(fallback = true)
           }
       }
   }

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/FlowControl.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/FlowControl.scala
@@ -27,11 +27,6 @@ private[jdbc] object FlowControl {
    */
   case object ContinueDelayed extends FlowControl
 
-  /**
-   * if the limited windows unable query anything, then fallback to full windows.
-   */
-  case object Fallback extends FlowControl
-
   /** Stop querying - used when we reach the desired offset */
   case object Stop extends FlowControl
 }

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/FlowControl.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/FlowControl.scala
@@ -27,6 +27,11 @@ private[jdbc] object FlowControl {
    */
   case object ContinueDelayed extends FlowControl
 
+  /**
+   * if the limited windows unable query anything, then fallback to full windows.
+   */
+  case object Fallback extends FlowControl
+
   /** Stop querying - used when we reach the desired offset */
   case object Stop extends FlowControl
 }

--- a/integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/integration/LimitWindowingStreamTest.scala
+++ b/integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/integration/LimitWindowingStreamTest.scala
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.pekko.persistence.jdbc.integration
+
+import org.apache.pekko.persistence.jdbc.journal.dao.LimitWindowingStreamTest
+import org.apache.pekko.persistence.jdbc.query.{ MysqlCleaner, OracleCleaner, PostgresCleaner, SqlServerCleaner }
+
+class PostgresLimitWindowingStreamTest
+    extends LimitWindowingStreamTest("postgres-application.conf")
+    with PostgresCleaner
+
+class MySQLLimitWindowingStreamTest
+    extends LimitWindowingStreamTest("mysql-application.conf")
+    with MysqlCleaner
+
+class OracleLimitWindowingStreamTest
+    extends LimitWindowingStreamTest("oracle-application.conf")
+    with OracleCleaner
+
+class SqlServerLimitWindowingStreamTest
+    extends LimitWindowingStreamTest("sqlserver-application.conf")
+    with SqlServerCleaner


### PR DESCRIPTION
## Motivation

- apply the suggestion that #180 has taken before being merged.
- for snapshoted event, use full-size window query to fetch the first sequence version.
- integration test for limitWindowsing.

it also fixed the test failed after #180 merged.

## Explan

In the normal case...(the sequence version always start from 1)

```
Query pid = test-account-1, from = 1, to = 501, batch-size= 500
Query pid = test-account-1, from = 501, to = 1001, batch-size= 500
Query pid = test-account-1, from = 1001, to = 1501, batch-size= 500
Query pid = test-account-1, total = 1000
```

After the snapshot, the existing sequence version may start from 1000 or higher.(or something happened unexpectedly, like the migrator test)(the persistenceActor  It will not be affected, because the Reply will query HigherSequenceNumber in advance, but queries such as `currentEventsByPersistenceId` can not be required)
In this case we should use full windows for the first query only.

```diff
- Query pid = test-account-1, from = 1, to = 501, batch-size= 500
+ Query pid = test-account-1, from = 1, to = 9223372036854775807, batch-size= 500
Query pid = test-account-1, from = 1501, to = 2001, batch-size= 500
Query pid = test-account-1, from = 2001, to = 2501, batch-size= 500
Query pid = test-account-1, total = 1000
```


