### PR TITLE
Update scala-library, scala-reflect to 2.13.17 (#349)

### DIFF
--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -12,7 +12,7 @@ import sbt._
 object Dependencies {
   // Keep in sync with .github CI build
   val Scala212 = "2.12.20"
-  val Scala213 = "2.13.16"
+  val Scala213 = "2.13.17"
   val Scala3 = "3.3.6"
   val ScalaVersions = Seq(Scala212, Scala213, Scala3)
 


### PR DESCRIPTION
cherry pick 629e9c17990537e2d3a4e8d092ade961c64a2468 #349 

the issue is that we update scala in pekko core, we need to upgrade in downstream modules too because sbt won't let you depend on a jar that depends on a newer version of scala (even at the patch level) unless you set a flag in sbt to disable the check