### PR TITLE
stop running link validator on PRs

### DIFF
--- a/.github/workflows/link-validator.yml
+++ b/.github/workflows/link-validator.yml
@@ -3,9 +3,9 @@ name: Link Validator
 permissions: {}
 
 on:
-  pull_request:
+  workflow_dispatch:
   schedule:
-    - cron:  '0 6 * * 1'
+    - cron: '0 6 * * 1'
 
 jobs:
   validate-links:


### PR DESCRIPTION
* the job is just a time sink - most recent failure I checked was our Pekko docs 503ing on the test run
* we are basically spamming the links and that encourages those sites to rate limit us
* the whole concept of link validation on every commit is turning out to just be a bad idea