### PR TITLE
use nvarchar instead of varchar for sql server

### DIFF
--- a/core/src/main/resources/schema/sqlserver/sqlserver-create-schema.sql
+++ b/core/src/main/resources/schema/sqlserver/sqlserver-create-schema.sql
@@ -1,12 +1,3 @@
-/*
-Pekko Persistence JDBC versions up to 1.3.0 used VARCHAR instead of NVARCHAR for string fields.
-This schema change is not applied automatically for existing databases so it is recommended
-that users modify their database schema themselves to use NVARCHAR to avoid potential issues with
-character encoding, especially when dealing with non-ASCII characters.
-If you stick with VARCHAR fields, it is highly recommended to not have the SQL Server JDBC client send
-strings as Unicode, by appending ;sendStringParametersAsUnicode=false to the JDBC connection string.
-*/
-
 CREATE TABLE event_journal(
     "ordering" BIGINT IDENTITY(1,1) NOT NULL,
     "deleted" BIT DEFAULT 0 NOT NULL,


### PR DESCRIPTION
Based on https://github.com/akka/akka-persistence-jdbc/pull/652 which is now available under the Apache License, Version 2.0.

SQL Server users with existing databases set up for pekko-persistence-jdbc will need to make this change to the table definitions themselves. Pekko only uses these scripts when creating fresh databases.

Pekko Persistence JDBC versions up to 1.3.0 used VARCHAR instead of NVARCHAR for string fields.
This schema change is not applied automatically for existing databases so it is recommended
that users modify their database schema themselves to use NVARCHAR to avoid potential issues with
character encoding, especially when dealing with non-ASCII characters.

If you stick with VARCHAR fields, it is highly recommended to not have the SQL Server JDBC client send
strings as Unicode, by appending `;sendStringParametersAsUnicode=false` to the JDBC connection string.