### PR TITLE
remove stray integration test refs

### DIFF
--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -23,7 +23,7 @@ trait CopyrightHeader extends AutoPlugin {
   override def trigger: PluginTrigger = allRequirements
 
   protected def headerMappingSettings: Seq[Def.Setting[_]] =
-    Seq(Compile, Test, IntegrationTest).flatMap { config =>
+    Seq(Compile, Test).flatMap { config =>
       inConfig(config)(
         Seq(
           headerLicense := Some(HeaderLicense.Custom(apacheHeader)),
@@ -35,8 +35,7 @@ trait CopyrightHeader extends AutoPlugin {
     }
 
   override def projectSettings: Seq[Def.Setting[_]] =
-    Def.settings(headerMappingSettings, additional) ++ Defaults.itSettings ++
-    headerSettings(IntegrationTest)
+    Def.settings(headerMappingSettings, additional) ++ Defaults.itSettings
 
   def additional: Seq[Def.Setting[_]] =
     Def.settings(Compile / compile := {


### PR DESCRIPTION
sbt has deprecated IntegrationTest scope and we have previously removed our use of it but some stray refs were left behind