### PR TITLE
use nvarchar instead of varchar for sql server (#382)

### DIFF
--- a/core/src/main/resources/schema/sqlserver/sqlserver-create-schema.sql
+++ b/core/src/main/resources/schema/sqlserver/sqlserver-create-schema.sql
@@ -1,17 +1,17 @@
 CREATE TABLE event_journal(
     "ordering" BIGINT IDENTITY(1,1) NOT NULL,
     "deleted" BIT DEFAULT 0 NOT NULL,
-    "persistence_id" VARCHAR(255) NOT NULL,
+    "persistence_id" NVARCHAR(255) NOT NULL,
     "sequence_number" NUMERIC(10,0) NOT NULL,
-    "writer" VARCHAR(255) NOT NULL,
+    "writer" NVARCHAR(255) NOT NULL,
     "write_timestamp" BIGINT NOT NULL,
-    "adapter_manifest" VARCHAR(MAX) NOT NULL,
+    "adapter_manifest" NVARCHAR(MAX) NOT NULL,
     "event_payload" VARBINARY(MAX) NOT NULL,
     "event_ser_id" INTEGER NOT NULL,
-    "event_ser_manifest" VARCHAR(MAX) NOT NULL,
+    "event_ser_manifest" NVARCHAR(MAX) NOT NULL,
     "meta_payload" VARBINARY(MAX),
     "meta_ser_id" INTEGER,
-    "meta_ser_manifest" VARCHAR(MAX)
+    "meta_ser_manifest" NVARCHAR(MAX)
     PRIMARY KEY ("persistence_id", "sequence_number")
 );
 
@@ -19,7 +19,7 @@ CREATE UNIQUE INDEX event_journal_ordering_idx ON event_journal(ordering);
 
 CREATE TABLE event_tag (
     "event_id" BIGINT NOT NULL,
-    "tag" VARCHAR(255) NOT NULL
+    "tag" NVARCHAR(255) NOT NULL
     PRIMARY KEY ("event_id","tag")
     constraint "fk_event_journal"
         foreign key("event_id")
@@ -28,14 +28,14 @@ CREATE TABLE event_tag (
 );
 
 CREATE TABLE "snapshot" (
-    "persistence_id" VARCHAR(255) NOT NULL,
+    "persistence_id" NVARCHAR(255) NOT NULL,
     "sequence_number" NUMERIC(10,0) NOT NULL,
     "created" BIGINT NOT NULL,
     "snapshot_ser_id" INTEGER NOT NULL,
-    "snapshot_ser_manifest" VARCHAR(255) NOT NULL,
+    "snapshot_ser_manifest" NVARCHAR(255) NOT NULL,
     "snapshot_payload" VARBINARY(MAX) NOT NULL,
     "meta_ser_id" INTEGER,
-    "meta_ser_manifest" VARCHAR(255),
+    "meta_ser_manifest" NVARCHAR(255),
     "meta_payload" VARBINARY(MAX),
     PRIMARY KEY ("persistence_id", "sequence_number")
   )
@@ -50,12 +50,12 @@ CREATE TABLE durable_state
     "global_offset"         BIGINT
         CONSTRAINT [df_global_offset] DEFAULT
         (NEXT VALUE FOR global_offset),
-    "persistence_id"        VARCHAR(255)   NOT NULL,
+    "persistence_id"        NVARCHAR(255)   NOT NULL,
     "revision"              NUMERIC(10, 0) NOT NULL,
     "state_payload"         VARBINARY(MAX) NOT NULL,
     "state_serial_id"       INTEGER        NOT NULL,
-    "state_serial_manifest" VARCHAR(MAX),
-    "tag"                   VARCHAR(255),
+    "state_serial_manifest" NVARCHAR(MAX),
+    "tag"                   NVARCHAR(255),
     "state_timestamp"       BIGINT         NOT NULL
         PRIMARY KEY ("persistence_id")
 );


### PR DESCRIPTION
cherry pick f499e376a939155d5a7663df2711f5711afcdf14 #382

Based on https://github.com/akka/akka-persistence-jdbc/pull/652 which is now available under the Apache License, Version 2.0.

SQL Server users with existing databases set up for pekko-persistence-jdbc will need to make this change to the table definitions themselves. Pekko only uses these scripts when creating fresh databases.

Pekko Persistence JDBC versions up to 1.3.0 used VARCHAR instead of NVARCHAR for string fields.
This schema change is not applied automatically for existing databases so it is recommended
that users modify their database schema themselves to use NVARCHAR to avoid potential issues with
character encoding, especially when dealing with non-ASCII characters.

If you stick with VARCHAR fields, it is highly recommended to not have the SQL Server JDBC client send
strings as Unicode, by appending `;sendStringParametersAsUnicode=false` to the JDBC connection string.