### PR TITLE
fix some misspellings

### DIFF
--- a/core/src/main/resources/reference.conf
+++ b/core/src/main/resources/reference.conf
@@ -59,7 +59,7 @@ pekko-persistence-jdbc {
         # Slick will use an async executor with a fixed size queue of 10.000 objects
         # The async executor is a connection pool for asynchronous execution of blocking I/O actions.
         # This is used for the asynchronous query execution API on top of blocking back-ends like JDBC.
-        queueSize = 10000 // number of objects that can be queued by the async exector
+        queueSize = 10000 // number of objects that can be queued by the async executor
 
         # This property controls the maximum number of milliseconds that a client (that's you) will wait for a connection
         # from the pool. If this time is exceeded without a connection becoming available, a SQLException will be thrown.
@@ -166,13 +166,13 @@ jdbc-journal {
   # Only used for the legacy schema
   tagSeparator = ${pekko-persistence-jdbc.tagSeparator}
 
-  # If you have data from akka-peristence-jdbc pre 5.0.0 use the legacy
+  # If you have data from akka-persistence-jdbc pre 5.0.0 use the legacy
   # pekko.persistence.jdbc.journal.dao.legacy.ByteArrayJournalDao Dao.
   dao = "org.apache.pekko.persistence.jdbc.journal.dao.DefaultJournalDao"
 
   # The size of the buffer used when queueing up events for batch writing. This number must be bigger then the number
   # of events that may be written concurrently. In other words this number must be bigger than the number of persistent
-  # actors that are actively peristing at the same time.
+  # actors that are actively persisting at the same time.
   bufferSize = 1000
   # The maximum size of the batches in which journal rows will be inserted
   batchSize = 400
@@ -227,7 +227,7 @@ jdbc-journal {
       # Slick will use an async executor with a fixed size queue of 10.000 objects
       # The async executor is a connection pool for asynchronous execution of blocking I/O actions.
       # This is used for the asynchronous query execution API on top of blocking back-ends like JDBC.
-      queueSize = 10000 // number of objects that can be queued by the async exector
+      queueSize = 10000 // number of objects that can be queued by the async executor
 
       # This property controls the maximum number of milliseconds that a client (that's you) will wait for a connection
       # from the pool. If this time is exceeded without a connection becoming available, a SQLException will be thrown.
@@ -356,7 +356,7 @@ jdbc-snapshot-store {
       # Slick will use an async executor with a fixed size queue of 10.000 objects
       # The async executor is a connection pool for asynchronous execution of blocking I/O actions.
       # This is used for the asynchronous query execution API on top of blocking back-ends like JDBC.
-      queueSize = 10000 // number of objects that can be queued by the async exector
+      queueSize = 10000 // number of objects that can be queued by the async executor
 
       # This property controls the maximum number of milliseconds that a client (that's you) will wait for a connection
       # from the pool. If this time is exceeded without a connection becoming available, a SQLException will be thrown.
@@ -511,7 +511,7 @@ jdbc-read-journal {
       # Slick will use an async executor with a fixed size queue of 10.000 objects
       # The async executor is a connection pool for asynchronous execution of blocking I/O actions.
       # This is used for the asynchronous query execution API on top of blocking back-ends like JDBC.
-      queueSize = 10000 // number of objects that can be queued by the async exector
+      queueSize = 10000 // number of objects that can be queued by the async executor
 
       # This property controls the maximum number of milliseconds that a client (that's you) will wait for a connection
       # from the pool. If this time is exceeded without a connection becoming available, a SQLException will be thrown.
@@ -648,7 +648,7 @@ jdbc-durable-state-store {
       # Slick will use an async executor with a fixed size queue of 10.000 objects
       # The async executor is a connection pool for asynchronous execution of blocking I/O actions.
       # This is used for the asynchronous query execution API on top of blocking back-ends like JDBC.
-      queueSize = 10000 // number of objects that can be queued by the async exector
+      queueSize = 10000 // number of objects that can be queued by the async executor
 
       # This property controls the maximum number of milliseconds that a client (that's you) will wait for a connection
       # from the pool. If this time is exceeded without a connection becoming available, a SQLException will be thrown.

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/TablesTestSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/TablesTestSpec.scala
@@ -82,7 +82,7 @@ abstract class TablesTestSpec extends AnyFlatSpec with Matchers {
       |      // slick will use an async executor with a fixed size queue of 10.000 objects
       |      // The async executor is a connection pool for asynchronous execution of blocking I/O actions.
       |      // This is used for the asynchronous query execution API on top of blocking back-ends like JDBC.
-      |      queueSize = 10000 // number of objects that can be queued by the async exector
+      |      queueSize = 10000 // number of objects that can be queued by the async executor
       |
       |      connectionTimeout = 30000 // This property controls the maximum number of milliseconds that a client (that's you) will wait for a connection from the pool. If this time is exceeded without a connection becoming available, a SQLException will be thrown. 1000ms is the minimum value. Default: 30000 (30 seconds)
       |      validationTimeout = 5000 // This property controls the maximum amount of time that a connection will be tested for aliveness. This value must be less than the connectionTimeout. The lowest accepted validation timeout is 1000ms (1 second). Default: 5000
@@ -142,7 +142,7 @@ abstract class TablesTestSpec extends AnyFlatSpec with Matchers {
       |      // slick will use an async executor with a fixed size queue of 10.000 objects
       |      // The async executor is a connection pool for asynchronous execution of blocking I/O actions.
       |      // This is used for the asynchronous query execution API on top of blocking back-ends like JDBC.
-      |      queueSize = 10000 // number of objects that can be queued by the async exector
+      |      queueSize = 10000 // number of objects that can be queued by the async executor
       |
       |      connectionTimeout = 30000 // This property controls the maximum number of milliseconds that a client (that's you) will wait for a connection from the pool. If this time is exceeded without a connection becoming available, a SQLException will be thrown. 1000ms is the minimum value. Default: 30000 (30 seconds)
       |      validationTimeout = 5000 // This property controls the maximum amount of time that a connection will be tested for aliveness. This value must be less than the connectionTimeout. The lowest accepted validation timeout is 1000ms (1 second). Default: 5000
@@ -212,7 +212,7 @@ abstract class TablesTestSpec extends AnyFlatSpec with Matchers {
       |      // slick will use an async executor with a fixed size queue of 10.000 objects
       |      // The async executor is a connection pool for asynchronous execution of blocking I/O actions.
       |      // This is used for the asynchronous query execution API on top of blocking back-ends like JDBC.
-      |      queueSize = 10000 // number of objects that can be queued by the async exector
+      |      queueSize = 10000 // number of objects that can be queued by the async executor
       |
       |      connectionTimeout = 30000 // This property controls the maximum number of milliseconds that a client (that's you) will wait for a connection from the pool. If this time is exceeded without a connection becoming available, a SQLException will be thrown. 1000ms is the minimum value. Default: 30000 (30 seconds)
       |      validationTimeout = 5000 // This property controls the maximum amount of time that a connection will be tested for aliveness. This value must be less than the connectionTimeout. The lowest accepted validation timeout is 1000ms (1 second). Default: 5000

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/configuration/PekkoPersistenceConfigTest.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/configuration/PekkoPersistenceConfigTest.scala
@@ -74,7 +74,7 @@ class PekkoPersistenceConfigTest extends AnyFlatSpec with Matchers {
           |      // slick will use an async executor with a fixed size queue of 10.000 objects
           |      // The async executor is a connection pool for asynchronous execution of blocking I/O actions.
           |      // This is used for the asynchronous query execution API on top of blocking back-ends like JDBC.
-          |      queueSize = 10000 // number of objects that can be queued by the async exector
+          |      queueSize = 10000 // number of objects that can be queued by the async executor
           |
           |      connectionTimeout = 30000 // This property controls the maximum number of milliseconds that a client (that's you) will wait for a connection from the pool. If this time is exceeded without a connection becoming available, a SQLException will be thrown. 1000ms is the minimum value. Default: 30000 (30 seconds)
           |      validationTimeout = 5000 // This property controls the maximum amount of time that a connection will be tested for aliveness. This value must be less than the connectionTimeout. The lowest accepted validation timeout is 1000ms (1 second). Default: 5000
@@ -132,7 +132,7 @@ class PekkoPersistenceConfigTest extends AnyFlatSpec with Matchers {
           |      // slick will use an async executor with a fixed size queue of 10.000 objects
           |      // The async executor is a connection pool for asynchronous execution of blocking I/O actions.
           |      // This is used for the asynchronous query execution API on top of blocking back-ends like JDBC.
-          |      queueSize = 10000 // number of objects that can be queued by the async exector
+          |      queueSize = 10000 // number of objects that can be queued by the async executor
           |
           |      connectionTimeout = 30000 // This property controls the maximum number of milliseconds that a client (that's you) will wait for a connection from the pool. If this time is exceeded without a connection becoming available, a SQLException will be thrown. 1000ms is the minimum value. Default: 30000 (30 seconds)
           |      validationTimeout = 5000 // This property controls the maximum amount of time that a connection will be tested for aliveness. This value must be less than the connectionTimeout. The lowest accepted validation timeout is 1000ms (1 second). Default: 5000
@@ -201,7 +201,7 @@ class PekkoPersistenceConfigTest extends AnyFlatSpec with Matchers {
           |      // slick will use an async executor with a fixed size queue of 10.000 objects
           |      // The async executor is a connection pool for asynchronous execution of blocking I/O actions.
           |      // This is used for the asynchronous query execution API on top of blocking back-ends like JDBC.
-          |      queueSize = 10000 // number of objects that can be queued by the async exector
+          |      queueSize = 10000 // number of objects that can be queued by the async executor
           |
           |      connectionTimeout = 30000 // This property controls the maximum number of milliseconds that a client (that's you) will wait for a connection from the pool. If this time is exceeded without a connection becoming available, a SQLException will be thrown. 1000ms is the minimum value. Default: 30000 (30 seconds)
           |      validationTimeout = 5000 // This property controls the maximum amount of time that a connection will be tested for aliveness. This value must be less than the connectionTimeout. The lowest accepted validation timeout is 1000ms (1 second). Default: 5000


### PR DESCRIPTION
fixed in #386 but might be useful to do separately, especially since we can backport this to 1.x