### PR TITLE
upgrade sbt plugins

### DIFF
--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -16,8 +16,8 @@ addSbtPlugin("com.github.sbt" % "sbt-java-formatter" % "0.9.0")
 // release
 addSbtPlugin("com.github.sbt" % "sbt-dynver" % "5.1.1")
 addSbtPlugin("net.bzzt" % "sbt-reproducible-builds" % "0.32")
-addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.4.5")
-addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.12")
+addSbtPlugin("com.github.pjfanning" % "sbt-pekko-build" % "0.4.7")
+addSbtPlugin("com.github.pjfanning" % "sbt-source-dist" % "0.1.13")
 // docs
 addSbtPlugin(("com.github.sbt" % "sbt-site-paradox" % "1.7.0").excludeAll(
   "com.lightbend.paradox", "sbt-paradox"))


### PR DESCRIPTION
main reason is sbt-pekko-build has changes to support testing with newer pekko snapshots