### PR TITLE
Update MySQL image version to 9.5.0

### DIFF
--- a/scripts/docker-compose.yml
+++ b/scripts/docker-compose.yml
@@ -14,7 +14,7 @@ services:
       - "5432:5432"  # credentials (docker:docker)
 
   mysql:
-    image: mysql:latest
+    image: mysql:9.5.0
     container_name: mysql-test
     environment:
       - "TZ=Europe/Amsterdam"


### PR DESCRIPTION
MySQL integration tests have started failing and 9.6.0 become latest release a few days ago and this may be why the tests started failing

#431 is open for investigation