### PR TITLE
Remove itSettings in projectSettings method

### DIFF
--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -35,7 +35,7 @@ trait CopyrightHeader extends AutoPlugin {
     }
 
   override def projectSettings: Seq[Def.Setting[_]] =
-    Def.settings(headerMappingSettings, additional) ++ Defaults.itSettings
+    Def.settings(headerMappingSettings, additional)
 
   def additional: Seq[Def.Setting[_]] =
     Def.settings(Compile / compile := {


### PR DESCRIPTION
IntegrationTest support in sbt is deprecated and we have removed almost all the code that used it