### PR TITLE
Add -Yfuture-lazy-vals for Scala 3.3.x builds

### DIFF
--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -54,6 +54,8 @@ object ProjectAutoPlugin extends AutoPlugin {
       (CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, _)) =>
           disciplineScalacOptions
+        case Some((3, _)) =>
+          Set("-Yfuture-lazy-vals")
         case _ =>
           Nil
       }).toSeq,


### PR DESCRIPTION
### Motivation

The Scala 3.3.8 compiler introduced the `-Yfuture-lazy-vals` flag ([scala/scala3-lts#637](https://github.com/scala/scala3-lts/pull/637)) to optionally use `VarHandle` instead of `sun.misc.Unsafe` for lazy val implementation. This prepares libraries for upcoming JDK releases that restrict `sun.misc.Unsafe` access.

### Modification

Add `-Yfuture-lazy-vals` to scalacOptions, conditionally applied only for Scala 3.3.x.

### Result

Scala 3.3.x build uses the future-proof `VarHandle`-based lazy val implementation, compatible with all JDK 9+ versions including future releases that restrict `sun.misc.Unsafe`.

### References

Refs scala/scala3-lts#637
Refs apache/pekko#3059