### PR TITLE
chore: Rewrite to scala3 syntax

### DIFF
--- a/.scalafmt.conf
+++ b/.scalafmt.conf
@@ -1,5 +1,5 @@
 version                                  = 3.11.1
-runner.dialect                           = scala213
+runner.dialect                           = scala213source3
 project.git                              = true
 style                                    = defaultWithAlign
 docstrings.style                         = Asterisk
@@ -73,3 +73,13 @@ rewriteTokens          = {
 }
 project.layout         = StandardConvention
 
+
+rewrite.scala3.convertToNewSyntax = true
+runner {
+  dialectOverride {
+    allowSignificantIndentation = false
+    allowAsForImportRename = false
+    allowStarWildcardImport = false
+    allowPostfixStarVarargSplices = false
+  }
+}

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
@@ -38,7 +38,7 @@ import pekko.pattern.pipe
 import pekko.persistence.jdbc.util.PluginVersionChecker
 
 object JdbcAsyncWriteJournal {
-  private case class WriteFinished(pid: String, f: Future[_])
+  private case class WriteFinished(pid: String, f: Future[?])
 
   /**
    * Extra Plugin API: May be used to issue in-place updates for events.
@@ -85,7 +85,7 @@ class JdbcAsyncWriteJournal(config: Config) extends AsyncWriteJournal {
 
   // readHighestSequence must be performed after pending write for a persistenceId
   // when the persistent actor is restarted.
-  private val writeInProgress: JMap[String, Future[_]] = new JHMap
+  private val writeInProgress: JMap[String, Future[?]] = new JHMap
 
   override def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
     // add timestamp to all payloads in all AtomicWrite messages

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/query/QueryTestSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/query/QueryTestSpec.scala
@@ -347,7 +347,7 @@ abstract class QueryTestSpec(config: String, configOverrides: Map[String, Config
 
   def withDao(f: JournalDao => Unit)(implicit system: ActorSystem, ec: ExecutionContext, mat: Materializer): Unit = {
     val fqcn: String = journalConfig.pluginConfig.dao
-    val args: immutable.Seq[(Class[_], AnyRef)] = immutable.Seq(
+    val args: immutable.Seq[(Class[?], AnyRef)] = immutable.Seq(
       (classOf[Database], db), (classOf[JdbcProfile], profile), (classOf[JournalConfig], journalConfig),
       (classOf[Serialization], SerializationExtension(system)), (classOf[ExecutionContext], ec),
       (classOf[Materializer], mat))

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/Payloads.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/Payloads.scala
@@ -29,7 +29,7 @@ class MyPayloadSerializer extends Serializer {
     case _               => throw new Exception("Unknown object for serialization")
   }
 
-  def fromBinary(bytes: Array[Byte], manifest: Option[Class[_]]): AnyRef = manifest match {
+  def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef = manifest match {
     case Some(MyPayloadClass) => MyPayload(s"${new String(bytes, "UTF-8")}")
     case Some(c)              => throw new Exception(s"unexpected manifest $c")
     case None                 => throw new Exception("no manifest")

--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/DurableStateStorePluginSpec.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/DurableStateStorePluginSpec.scala
@@ -44,7 +44,7 @@ abstract class DurableStateStorePluginSpec(config: Config, profile: JdbcProfile)
         .get(system)
         .durableStateStoreFor[JdbcDurableStateStore[String]](JdbcDurableStateStore.Identifier)
 
-      store shouldBe a[JdbcDurableStateStore[_]]
+      store shouldBe a[JdbcDurableStateStore[?]]
       store.system.settings.config shouldBe system.settings.config
       store.profile shouldBe profile
     }
@@ -114,7 +114,7 @@ abstract class DurableStateStoreSchemaPluginSpec(val config: Config, profile: Jd
         .get(system)
         .durableStateStoreFor[JdbcDurableStateStore[String]](JdbcDurableStateStore.Identifier)
 
-      store shouldBe a[JdbcDurableStateStore[_]]
+      store shouldBe a[JdbcDurableStateStore[?]]
       store.system.settings.config shouldBe system.settings.config
       store.profile shouldBe profile
     }

--- a/project/CopyrightHeader.scala
+++ b/project/CopyrightHeader.scala
@@ -22,7 +22,7 @@ trait CopyrightHeader extends AutoPlugin {
 
   override def trigger: PluginTrigger = allRequirements
 
-  protected def headerMappingSettings: Seq[Def.Setting[_]] =
+  protected def headerMappingSettings: Seq[Def.Setting[?]] =
     Seq(Compile, Test).flatMap { config =>
       inConfig(config)(
         Seq(
@@ -34,10 +34,10 @@ trait CopyrightHeader extends AutoPlugin {
             HeaderFileType("template") -> cStyleComment)))
     }
 
-  override def projectSettings: Seq[Def.Setting[_]] =
+  override def projectSettings: Seq[Def.Setting[?]] =
     Def.settings(headerMappingSettings, additional)
 
-  def additional: Seq[Def.Setting[_]] =
+  def additional: Seq[Def.Setting[?]] =
     Def.settings(Compile / compile := {
         (Compile / headerCreate).value
         (Compile / compile).value

--- a/project/JavaFormatter.scala
+++ b/project/JavaFormatter.scala
@@ -28,7 +28,7 @@ object JavaFormatter extends AutoPlugin {
   import sbt._
   import sbt.io._
 
-  override lazy val projectSettings: Seq[Def.Setting[_]] =
+  override lazy val projectSettings: Seq[Def.Setting[?]] =
     Seq(
       // below is for sbt java formatter
       javafmt / excludeFilter := {

--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -35,7 +35,7 @@ object ProjectAutoPlugin extends AutoPlugin {
 
   override val trigger: PluginTrigger = allRequirements
 
-  override val projectSettings: Seq[Setting[_]] = Seq(
+  override val projectSettings: Seq[Setting[?]] = Seq(
     crossVersion := CrossVersion.binary,
     crossScalaVersions := Dependencies.ScalaVersions,
     scalaVersion := Dependencies.Scala213,


### PR DESCRIPTION
### Motivation
Let Scala 3 Community build compile pekko-persistence-jdbc.

### Modification
Update `.scalafmt.conf` dialect to `scala213source3` and enable Scala 3 syntax rewrite rules (`rewrite.scala3.convertToNewSyntax`), then reformat all sources. Key changes:
- Wildcard type `_` → `?` (e.g. `Class[_]` → `Class[?]`)

### Result
Code is compatible with Scala 3 compiler when built with the community build.

### Tests
Not run - formatting only

### References
Refs apache/pekko#3048