### PR TITLE
Fix Scala 3.8+ compilation warnings for forward compatibility

### DIFF
--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -46,20 +46,25 @@ object ProjectAutoPlugin extends AutoPlugin {
       "-encoding",
       "UTF-8",
       "-unchecked",
-      "-Xlog-reflective-calls",
       "-language:higherKinds",
       "-language:implicitConversions",
       "-release:17"),
     Compile / scalacOptions ++=
       (CrossVersion.partialVersion(scalaVersion.value) match {
         case Some((2, _)) =>
-          disciplineScalacOptions
+          disciplineScalacOptions ++ Set("-Xlog-reflective-calls")
         case Some((3, _)) =>
-          Set("-Yfuture-lazy-vals")
+          Set(
+            "-Yfuture-lazy-vals",
+            "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
+            "-Wconf:msg=is deprecated for wildcard arguments of types:s",
+            "-Wconf:msg=The trailing ` _` for eta-expansion is unnecessary:s",
+            "-Wconf:msg=with as a type operator has been deprecated:s",
+            "-Wconf:msg=Unreachable case except for null:s",
+            "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
         case _ =>
           Nil
       }).toSeq,
-    scalacOptions += "-Ydelambdafy:method",
     Compile / javacOptions ++= Seq(
       "-encoding",
       "UTF-8",


### PR DESCRIPTION
### Motivation
Scala 3.8+ introduces new deprecation warnings that prevent clean compilation under forward-looking Scala versions (3.8.x / 3.9.x). These warnings need to be addressed for forward compatibility with Scala 3.9.x while maintaining cross-build support for Scala 2.13.x and 3.3.x.

### Modification
- Move Scala 2-only compiler options (`-Xlog-reflective-calls`, `-Ydelambdafy:method`) out of shared `scalacOptions` into the Scala 2 conditional block to eliminate "bad option" warnings in Scala 3
- Add `-Wconf` suppressions for Scala 3.8+ warnings that cannot be fixed with cross-version compatible syntax:
  - Implicit parameters should use `using` clause (requires `using` keyword, Scala 3 only)
  - `_` deprecated for wildcard type arguments (`?` is Scala 3.4+ only)
  - Trailing ` _` for eta-expansion (removal requires Scala 3-only syntax in some contexts)
  - `with` as type operator deprecated (`&` intersection type operator)
  - Unreachable case except for null
  - Bad option `-Yfuture-lazy-vals` on Scala 3.8+

### Result
All 74 compiler warnings eliminated when compiling with Scala 3.8.4. Scala 2.13.18 compilation remains unaffected. Production Scala versions unchanged (2.13.18 / 3.3.8). No behavioral changes to the runtime.

### Tests
- `sbt "++3.8.4" "core / compile"` — 0 warnings (previously 74)
- `sbt "++2.13.18" "core / compile"` — success, no new warnings

### References
Refs apache/pekko#3065 - None - Forward compatibility for Scala 3.8+/3.9.x