### PR TITLE
chore: resolve all compiler warnings in core module and build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -23,6 +23,8 @@ ThisBuild / reproducibleBuildsCheckResolver := Resolver.ApacheMavenStagingRepo
 
 ThisBuild / javafmtFormatterCompatibleJavaVersion := 17
 
+Global / excludeLintKeys += previewPath
+
 lazy val `pekko-persistence-jdbc` = project
   .in(file("."))
   .enablePlugins(ScalaUnidocPlugin)

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
@@ -112,7 +112,7 @@ class JdbcAsyncWriteJournal(config: Config) extends AsyncWriteJournal {
       case f    =>
         // we must fetch the highest sequence number after the previous write has completed
         // If the previous write failed then we can ignore this
-        f.recover { case _ => () }.flatMap(_ => fetchHighestSeqNr())
+        f.map(_ => ()).recover { case _ => () }.flatMap(_ => fetchHighestSeqNr())
     }
   }
 

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/package.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/package.scala
@@ -14,9 +14,11 @@
 
 package org.apache.pekko.persistence.jdbc.journal.dao
 
+import scala.annotation.nowarn
 import scala.collection.immutable.Set
 
 package object legacy {
+  @nowarn("msg=it is not recommended to define classes/objects inside of package objects")
   final case class JournalRow(
       ordering: Long,
       deleted: Boolean,

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/JdbcDurableStateStore.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/state/scaladsl/JdbcDurableStateStore.scala
@@ -244,15 +244,6 @@ class JdbcDurableStateStore[A](
           row.stateTimestamp))
   }
 
-  private def updateDurableState(row: DurableStateTables.DurableStateRow) = {
-    import queries._
-
-    for {
-      s <- getSequenceNextValueExpr()
-      u <- updateDbWithDurableState(row, s.head)
-    } yield u
-  }
-
   private def insertDurableState(row: DurableStateTables.DurableStateRow) = {
     import queries._
 

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/util/TrySeq.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/util/TrySeq.scala
@@ -14,11 +14,13 @@
 
 package org.apache.pekko.persistence.jdbc.util
 
+import scala.annotation.nowarn
 import scala.collection.immutable._
 import scala.util.{ Failure, Success, Try }
 
 object TrySeq {
   def sequence[A](seq: Seq[Try[A]]): Try[Seq[A]] = {
+    @nowarn("msg=match may not be exhaustive")
     def recurse(remaining: Seq[Try[A]], processed: Seq[A]): Try[Seq[A]] =
       remaining match {
         case Seq()                 => Success(processed)


### PR DESCRIPTION
### Motivation
Several compiler warnings were emitted during compilation of the core module and sbt build loading:
- `JdbcAsyncWriteJournal.scala:115` - "a type was inferred to be `Any`; this may indicate a programming error"
- `legacy/package.scala:20` - "it is not recommended to define classes/objects inside of package objects"
- `JdbcDurableStateStore.scala:247` - "private method updateDurableState is never used"
- `TrySeq.scala:23` - "match may not be exhaustive"
- `build.sbt:92` - sbt lint warning about unused key `previewPath`

### Modification
- **JdbcAsyncWriteJournal**: add `.map(_ => ())` before `.recover` to explicitly convert `Future[?]` to `Future[Unit]`, avoiding the `Any` type inference when the wildcard-typed future is recovered.
- **legacy/package.scala**: add `@nowarn("msg=it is not recommended to define classes/objects inside of package objects")` on `JournalRow`. This is a known Scala pattern and safe to suppress.
- **JdbcDurableStateStore**: remove unused private `updateDurableState` method. The `upsertObject` method already calls `queries.updateDbWithDurableState` directly, making the wrapper dead code.
- **TrySeq**: add `@nowarn("msg=match may not be exhaustive")` on the `recurse` method. The match is exhaustive in practice since `Try` is sealed (only `Success` and `Failure`), but the compiler cannot prove this with `Seq` pattern decomposition.
- **build.sbt**: add `Global / excludeLintKeys += previewPath` to suppress the sbt lint warning. The key is set for the Paradox site plugin and intentionally kept.

### Result
Clean compilation with zero warnings from both the Scala compiler and sbt lint checks.

### Tests
- `sbt "clean; compile"` passes with no warnings

### References
None - compiler warning cleanup