### PR TITLE
fix: make -Yfuture-lazy-vals conditional for Scala 3.9+

### DIFF
--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -55,13 +55,12 @@ object ProjectAutoPlugin extends AutoPlugin {
           disciplineScalacOptions ++ Set("-Xlog-reflective-calls")
         case Some((3, _)) =>
           Set(
-            "-Yfuture-lazy-vals",
             "-Wconf:msg=Implicit parameters should be provided with a `using` clause:s",
             "-Wconf:msg=is deprecated for wildcard arguments of types:s",
             "-Wconf:msg=The trailing ` _` for eta-expansion is unnecessary:s",
             "-Wconf:msg=with as a type operator has been deprecated:s",
-            "-Wconf:msg=Unreachable case except for null:s",
-            "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
+            "-Wconf:msg=Unreachable case except for null:s") ++
+          (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)) Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s") else Seq.empty)
         case _ =>
           Nil
       }).toSeq,

--- a/project/ProjectAutoPlugin.scala
+++ b/project/ProjectAutoPlugin.scala
@@ -60,7 +60,9 @@ object ProjectAutoPlugin extends AutoPlugin {
             "-Wconf:msg=The trailing ` _` for eta-expansion is unnecessary:s",
             "-Wconf:msg=with as a type operator has been deprecated:s",
             "-Wconf:msg=Unreachable case except for null:s") ++
-          (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)) Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s") else Seq.empty)
+          (if (CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9))
+             Seq("-Yfuture-lazy-vals", "-Wconf:msg=bad option.*-Yfuture-lazy-vals:s")
+           else Seq.empty)
         case _ =>
           Nil
       }).toSeq,


### PR DESCRIPTION
### Motivation
Scala 3.9 removed the `-Yfuture-lazy-vals` compiler option as the future lazy vals behavior is now the default. Passing this flag on Scala 3.9+ causes a compilation error.

### Modification
Made `-Yfuture-lazy-vals` conditional on Scala minor version < 9 using `CrossVersion.partialVersion(scalaVersion.value).exists(_._2 < 9)`.

### Result
Project compiles on both Scala 3.3.x (which needs the flag) and Scala 3.9+ (which has the behavior by default).

### Tests
- `sbt "++3.9.0-RC1!; compile"` — no -Yfuture-lazy-vals error
- `sbt "++3.3.7!; compile"` — flag still applied

### References
- Part of the Scala 3.9 compatibility effort across all Pekko projects