### PR TITLE
Change Java setup from version 17 to 8 (1.x releases)

### DIFF
--- a/.github/workflows/stage-release-candidate.yml
+++ b/.github/workflows/stage-release-candidate.yml
@@ -205,11 +205,11 @@ jobs:
           fetch-tags: true
           persist-credentials: false
 
-      - name: Setup Java 17
+      - name: Setup Java 8
         uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5.2.0
         with:
           distribution: temurin
-          java-version: 17
+          java-version: 8
 
       - name: Install sbt
         uses: sbt/setup-sbt@af116cce31c00823d3903ce687f9cda3a4f19f1b # v1.2.1


### PR DESCRIPTION
The 1.3.0 release was done with a CI job that used Java 17. We have `-release:8` in the sbt scripting so hopefully, we should be ok. I did test pekko-projections with the jars and they seemed to work with Java 8.
Still would prefer to ensure that future 1.x releases are built with Java 8. 

https://github.com/apache/pekko-projection/pull/515