### PR TITLE
fix: fix scaladoc warnings in core module

### DIFF
--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/db/SlickExtension.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/db/SlickExtension.scala
@@ -49,7 +49,7 @@ class SlickExtensionImpl(system: ExtendedActorSystem) extends Extension {
  * A SlickDatabaseProvider is loaded using reflection,
  * The instance is created using the following:
  * - The fully qualified class name as configured in `jdbc-journal.database-provider-fqcn`.
- * - The constructor with one argument of type [[pekko.actor.ActorSystem]] is used to create the instance.
+ * - The constructor with one argument of type [[org.apache.pekko.actor.ActorSystem ActorSystem]] is used to create the instance.
  *   Therefore the class must have such a constructor.
  */
 trait SlickDatabaseProvider {

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/JdbcAsyncWriteJournal.scala
@@ -44,7 +44,7 @@ object JdbcAsyncWriteJournal {
    * Extra Plugin API: May be used to issue in-place updates for events.
    * To be used only for data migrations such as "encrypt all events" and similar operations.
    *
-   * The write payload may be wrapped in a [[pekko.persistence.journal.Tagged]],
+   * The write payload may be wrapped in a [[org.apache.pekko.persistence.journal.Tagged Tagged]],
    * in which case the new tags will overwrite the existing tags of the event.
    */
   final case class InPlaceUpdateEvent(persistenceId: String, seqNr: Long, write: AnyRef)

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/JournalDao.scala
@@ -33,7 +33,7 @@ trait JournalDao extends JournalDaoWithReadMessages {
   def highestSequenceNr(persistenceId: String, fromSequenceNr: Long): Future[Long]
 
   /**
-   * @see [[pekko.persistence.journal.AsyncWriteJournal.asyncWriteMessages(messages)]]
+   * @see `org.apache.pekko.persistence.journal.AsyncWriteJournal.asyncWriteMessages(messages)`
    */
   def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]]
 }

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/journal/dao/legacy/ByteArrayJournalDao.scala
@@ -67,7 +67,7 @@ trait BaseByteArrayJournalDao
   }
 
   /**
-   * @see [[pekko.persistence.journal.AsyncWriteJournal.asyncWriteMessages(messages)]]
+   * @see `org.apache.pekko.persistence.journal.AsyncWriteJournal.asyncWriteMessages(messages)`
    */
   def asyncWriteMessages(messages: Seq[AtomicWrite]): Future[Seq[Try[Unit]]] = {
     val serializedTries: Seq[Try[Seq[JournalRow]]] = serializer.serialize(messages)

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/javadsl/JdbcReadJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/javadsl/JdbcReadJournal.scala
@@ -135,7 +135,7 @@ class JdbcReadJournal(journal: ScalaJdbcReadJournal)
    * The stream is not completed when it reaches the end of the currently stored events,
    * but it continues to push new events when new events are persisted.
    * Corresponding query that is completed when it reaches the end of the currently
-   * stored events is provided by [[CurrentEventsByTagQuery#currentEventsByTag]].
+   * stored events is provided by [[org.apache.pekko.persistence.query.javadsl.CurrentEventsByTagQuery#currentEventsByTag]].
    */
   override def eventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] =
     journal.eventsByTag(tag, offset).asJava

--- a/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
+++ b/core/src/main/scala/org/apache/pekko/persistence/jdbc/query/scaladsl/JdbcReadJournal.scala
@@ -326,7 +326,7 @@ class JdbcReadJournal(config: Config, configPath: String)(implicit val system: E
    * The stream is not completed when it reaches the end of the currently stored events,
    * but it continues to push new events when new events are persisted.
    * Corresponding query that is completed when it reaches the end of the currently
-   * stored events is provided by [[CurrentEventsByTagQuery#currentEventsByTag]].
+   * stored events is provided by [[org.apache.pekko.persistence.query.scaladsl.CurrentEventsByTagQuery#currentEventsByTag]].
    */
   override def eventsByTag(tag: String, offset: Offset): Source[EventEnvelope, NotUsed] =
     eventsByTag(tag, offset.value)


### PR DESCRIPTION
### Motivation
Running `sbt doc` produces scaladoc warnings about unresolvable or incorrect links in the core module.

### Modification
- `db/SlickExtension.scala`: Use fully qualified `org.apache.pekko.actor.ActorSystem` path for the ActorSystem link
- `journal/dao/JournalDao.scala`: Replace broken method link with backtick-quoted code
- `journal/dao/legacy/ByteArrayJournalDao.scala`: Replace broken method link with backtick-quoted code
- `journal/JdbcAsyncWriteJournal.scala`: Use fully qualified `org.apache.pekko.persistence.journal.Tagged` path for the Tagged link
- `query/javadsl/JdbcReadJournal.scala`: Use fully qualified path for CurrentEventsByTagQuery link
- `query/scaladsl/JdbcReadJournal.scala`: Use fully qualified path for CurrentEventsByTagQuery link

### Result
Scaladoc warnings are eliminated.

### Tests
Not run - docs only

### References
None