### PR TITLE
feat: add Scala 3.8.4 cross-compilation target

### DIFF
--- a/.github/workflows/h2-test.yml
+++ b/.github/workflows/h2-test.yml
@@ -19,8 +19,10 @@ jobs:
         include:
           - { java-version: 17, scala-version: 2.13, sbt-opts: '' }
           - { java-version: 17, scala-version: 3.3,  sbt-opts: '' }
+          - { java-version: 17, scala-version: 3.8,  sbt-opts: '' }
           - { java-version: 21, scala-version: 2.13, sbt-opts: '' }
           - { java-version: 21, scala-version: 3.3,  sbt-opts: '' }
+          - { java-version: 21, scala-version: 3.8,  sbt-opts: '' }
     steps:
       - name: Checkout
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7.0.0

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -13,7 +13,8 @@ object Dependencies {
   // Keep in sync with .github CI build
   val Scala213 = "2.13.18"
   val Scala3 = "3.3.8"
-  val ScalaVersions = Seq(Scala213, Scala3)
+  val Scala3Next = "3.8.4"
+  val ScalaVersions = Seq(Scala213, Scala3, Scala3Next)
 
   val PekkoVersion = PekkoCoreDependency.version
 


### PR DESCRIPTION
### Motivation
Ensure pekko-persistence-jdbc compiles and tests pass on the next Scala 3 release line (3.8.x), preparing for future Scala 3.9.x compatibility.

### Modification
- Add `Scala3Next = "3.8.4"` to Dependencies.scala
- Add Scala 3.8.4 to `ScalaVersions` / `crossScalaVersions`
- Add `"3.8"` to CI matrices in all relevant workflow files

### Result
CI now compiles and tests against Scala 2.13, 3.3, and 3.8. Publishing continues with Scala 3.3.8.

### Tests
CI will validate

### References
None - proactive compatibility testing