### PR TITLE
Use StandardCharsets.UTF_8 for payload serialization

### DIFF
--- a/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/Payloads.scala
+++ b/core/src/test/scala/org/apache/pekko/persistence/jdbc/state/Payloads.scala
@@ -14,6 +14,8 @@
 
 package org.apache.pekko.persistence.jdbc.state
 
+import java.nio.charset.StandardCharsets
+
 import org.apache.pekko.serialization._
 
 final case class MyPayload(data: String)
@@ -25,12 +27,12 @@ class MyPayloadSerializer extends Serializer {
   def includeManifest: Boolean = true
 
   def toBinary(o: AnyRef): Array[Byte] = o match {
-    case MyPayload(data) => s"$data".getBytes("UTF-8")
+    case MyPayload(data) => s"$data".getBytes(StandardCharsets.UTF_8)
     case _               => throw new Exception("Unknown object for serialization")
   }
 
   def fromBinary(bytes: Array[Byte], manifest: Option[Class[?]]): AnyRef = manifest match {
-    case Some(MyPayloadClass) => MyPayload(s"${new String(bytes, "UTF-8")}")
+    case Some(MyPayloadClass) => MyPayload(s"${new String(bytes, StandardCharsets.UTF_8)}")
     case Some(c)              => throw new Exception(s"unexpected manifest $c")
     case None                 => throw new Exception("no manifest")
   }


### PR DESCRIPTION
Summary: Replace UTF-8 string arguments with StandardCharsets.UTF_8 in test payload serialization. Verification: ran formatting, core Test compile, git diff --check, and residual charset literal searches.