### PR TITLE
fix for flaky JournalMigratorTest

### DIFF
--- a/migrator-integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/migrator/JournalMigratorTest.scala
+++ b/migrator-integration-test/src/test/scala/org/apache/pekko/persistence/jdbc/migrator/JournalMigratorTest.scala
@@ -42,9 +42,9 @@ abstract class JournalMigratorTest(configName: String) extends MigratorSpec(conf
     } // legacy persistence
     withActorSystem { implicit systemNew =>
       withReadJournal { implicit readJournal =>
+        countJournal().futureValue shouldBe 0 // before migration
+        JournalMigrator(SlickDatabase.profile(config, "slick")).migrate().futureValue shouldBe Done
         eventually {
-          countJournal().futureValue shouldBe 0 // before migration
-          JournalMigrator(SlickDatabase.profile(config, "slick")).migrate().futureValue shouldBe Done
           countJournal().futureValue shouldBe 9 // after migration
         }
         withTestActors() { (actorB1, actorB2, actorB3) =>
@@ -78,20 +78,20 @@ abstract class JournalMigratorTest(configName: String) extends MigratorSpec(conf
     } // legacy persistence
     withActorSystem { implicit systemNew =>
       withReadJournal { implicit readJournal =>
+        countJournal().futureValue shouldBe 0 // before migration
+        JournalMigrator(SlickDatabase.profile(config, "slick")).migrate().futureValue shouldBe Done
         eventually {
-          countJournal().futureValue shouldBe 0 // before migration
-          JournalMigrator(SlickDatabase.profile(config, "slick")).migrate().futureValue shouldBe Done
           countJournal().futureValue shouldBe 3000 // after migration
-          val allEvents: Seq[Seq[AccountEvent]] = events().futureValue
-          allEvents.size shouldBe 3
-          val seq1: Seq[Int] = allEvents.head.map(_.amount)
-          val seq2: Seq[Int] = allEvents(1).map(_.amount)
-          val seq3: Seq[Int] = allEvents(2).map(_.amount)
-          val expectedResult: Seq[Int] = 0 to 999
-          seq1 shouldBe expectedResult
-          seq2 shouldBe expectedResult
-          seq3 shouldBe expectedResult
         }
+        val allEvents: Seq[Seq[AccountEvent]] = events().futureValue
+        allEvents.size shouldBe 3
+        val seq1: Seq[Int] = allEvents.head.map(_.amount)
+        val seq2: Seq[Int] = allEvents(1).map(_.amount)
+        val seq3: Seq[Int] = allEvents(2).map(_.amount)
+        val expectedResult: Seq[Int] = 0 to 999
+        seq1 shouldBe expectedResult
+        seq2 shouldBe expectedResult
+        seq3 shouldBe expectedResult
       }
     } // new persistence
   }
@@ -116,18 +116,18 @@ abstract class JournalMigratorTest(configName: String) extends MigratorSpec(conf
     } // legacy persistence
     withActorSystem { implicit systemNew =>
       withReadJournal { implicit readJournal =>
+        countJournal().futureValue shouldBe 0 // before migration
+        JournalMigrator(SlickDatabase.profile(config, "slick")).migrate().futureValue shouldBe Done
         eventually {
-          countJournal().futureValue shouldBe 0 // before migration
-          JournalMigrator(SlickDatabase.profile(config, "slick")).migrate().futureValue shouldBe Done
           countJournal().futureValue shouldBe 3000 // after migration
-          val evenEvents: Seq[AccountEvent] = eventsByTag(MigratorSpec.Even).futureValue
-          evenEvents.size shouldBe 1500
-          evenEvents.forall(e => e.amount % 2 == 0) shouldBe true
-
-          val oddEvents: Seq[AccountEvent] = eventsByTag(MigratorSpec.Odd).futureValue
-          oddEvents.size shouldBe 1500
-          oddEvents.forall(e => e.amount % 2 == 1) shouldBe true
         }
+        val evenEvents: Seq[AccountEvent] = eventsByTag(MigratorSpec.Even).futureValue
+        evenEvents.size shouldBe 1500
+        evenEvents.forall(e => e.amount % 2 == 0) shouldBe true
+
+        val oddEvents: Seq[AccountEvent] = eventsByTag(MigratorSpec.Odd).futureValue
+        oddEvents.size shouldBe 1500
+        oddEvents.forall(e => e.amount % 2 == 1) shouldBe true
       }
     } // new persistence
   }


### PR DESCRIPTION
https://github.com/apache/pekko-persistence-jdbc/actions/runs/30263053265/job/89967216405

```
[info] - should migrate the event journal preserving the order of events *** FAILED *** (17 seconds, 194 milliseconds)
[info]   The code passed to eventually never returned normally. Attempted 1 times over 10.014821691 seconds. Last failure message: A timeout occurred waiting for a future to complete. Waited 10000000000 nanoseconds.. (JournalMigratorTest.scala:81)
[info]   org.scalatest.exceptions.TestFailedDueToTimeoutException:
[info]   at org.scalatest.enablers.Retrying$$anon$4.tryTryAgain$2(Retrying.scala:219)
[info]   at org.scalatest.enablers.Retrying$$anon$4.retry(Retrying.scala:226)
[info]   at org.scalatest.concurrent.Eventually.eventually(Eventually.scala:415)
[info]   at org.scalatest.concurrent.Eventually.eventually$(Eventually.scala:414)
[info]   at org.apache.pekko.persistence.jdbc.migrator.MigratorSpec.eventually(MigratorSpec.scala:38)
[info]   at org.apache.pekko.persistence.jdbc.migrator.JournalMigratorTest.$anonfun$new$18(JournalMigratorTest.scala:81)
[info]   at org.apache.pekko.persistence.jdbc.migrator.JournalMigratorTest.$anonfun$new$18$adapted(JournalMigratorTest.scala:80)
[info]   at org.apache.pekko.persistence.jdbc.migrator.MigratorSpec.withReadJournal(MigratorSpec.scala:147)
[info]   at org.apache.pekko.persistence.jdbc.migrator.JournalMigratorTest.$anonfun$new$17(JournalMigratorTest.scala:80)
[info]   at org.apache.pekko.persistence.jdbc.migrator.JournalMigratorTest.$anonfun$new$17$adapted(JournalMigratorTest.scala:79)
[info]   at org.apache.pekko.persistence.jdbc.migrator.MigratorSpec.withActorSystem(MigratorSpec.scala:121)
[info]   at org.apache.pekko.persistence.jdbc.migrator.JournalMigratorTest.$anonfun$new$11(JournalMigratorTest.scala:79)
[info]   at scala.runtime.java8.JFunction0$mcV$sp.apply(JFunction0$mcV$sp.scala:18)
[info]   at org.scalatest.OutcomeOf.outcomeOf(OutcomeOf.scala:85)
[info]   at org.scalatest.OutcomeOf.outcomeOf$(OutcomeOf.scala:83)
[info]   at org.scalatest.OutcomeOf$.outcomeOf(OutcomeOf.scala:104)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:22)
[info]   at org.scalatest.Transformer.apply(Transformer.scala:20)
[info]   at org.scalatest.flatspec.AnyFlatSpecLike$$anon$5.apply(AnyFlatSpecLike.scala:1832)
[info]   at org.scalatest.TestSuite.withFixture(TestSuite.scala:196)
[info]   at org.scalatest.TestSuite.withFixture$(TestSuite.scala:195)
[info]   at org.scalatest.flatspec.AnyFlatSpec.withFixture(AnyFlatSpec.scala:1686)
[info]   at org.scalatest.flatspec.AnyFlatSpecLike.invokeWithFixture$1(AnyFlatSpecLike.scala:1830)
[info]   at org.scalatest.flatspec.AnyFlatSpecLike.$anonfun$runTest$1(AnyFlatSpecLike.scala:1842)
[info]   at org.scalatest.SuperEngine.runTestImpl(Engine.scala:306)
[info]   at org.scalatest.flatspec.AnyFlatSpecLike.runTest(AnyFlatSpecLike.scala:1842)
[info]   at org.scalatest.flatspec.AnyFlatSpecLike.runTest$(AnyFlatSpecLike.scala:1824)
[info]   at org.apache.pekko.persistence.jdbc.migrator.MigratorSpec.org$scalatest$BeforeAndAfterEach$$super$runTest(MigratorSpec.scala:38)
[info]   at org.scalatest.BeforeAndAfterEach.runTest(BeforeAndAfterEach.scala:234)
[info]   at org.scalatest.BeforeAndAfterEach.runTest$(BeforeAndAfterEach.scala:227)
[info]   at org.apache.pekko.persistence.jdbc.migrator.MigratorSpec.runTest(MigratorSpec.scala:38)
[info]   at org.scalatest.flatspec.AnyFlatSpecLike.$anonfun$runTests$1(AnyFlatSpecLike.scala:1900)
[info]   at org.scalatest.SuperEngine.$anonfun$runTestsInBranch$1(Engine.scala:413)
[info]   at scala.collection.immutable.List.foreach(List.scala:323)
[info]   at org.scalatest.SuperEngine.traverseSubNodes$1(Engine.scala:401)
[info]   at org.scalatest.SuperEngine.runTestsInBranch(Engine.scala:396)
[info]   at org.scalatest.SuperEngine.runTestsImpl(Engine.scala:475)
[info]   at org.scalatest.flatspec.AnyFlatSpecLike.runTests(AnyFlatSpecLike.scala:1900)
[info]   at org.scalatest.flatspec.AnyFlatSpecLike.runTests$(AnyFlatSpecLike.scala:1899)
[info]   at org.scalatest.flatspec.AnyFlatSpec.runTests(AnyFlatSpec.scala:1686)
[info]   at org.scalatest.Suite.run(Suite.scala:1114)
[info]   at org.scalatest.Suite.run$(Suite.scala:1096)
[info]   at org.scalatest.flatspec.AnyFlatSpec.org$scalatest$flatspec$AnyFlatSpecLike$$super$run(AnyFlatSpec.scala:1686)
[info]   at org.scalatest.flatspec.AnyFlatSpecLike.$anonfun$run$1(AnyFlatSpecLike.scala:1945)
[info]   at org.scalatest.SuperEngine.runImpl(Engine.scala:535)
[info]   at org.scalatest.flatspec.AnyFlatSpecLike.run(AnyFlatSpecLike.scala:1945)
[info]   at org.scalatest.flatspec.AnyFlatSpecLike.run$(AnyFlatSpecLike.scala:1943)
[info]   at org.apache.pekko.persistence.jdbc.migrator.MigratorSpec.org$scalatest$BeforeAndAfterAll$$super$run(MigratorSpec.scala:38)
[info]   at org.scalatest.BeforeAndAfterAll.liftedTree1$1(BeforeAndAfterAll.scala:213)
[info]   at org.scalatest.BeforeAndAfterAll.run(BeforeAndAfterAll.scala:210)
[info]   at org.scalatest.BeforeAndAfterAll.run$(BeforeAndAfterAll.scala:208)
[info]   at org.apache.pekko.persistence.jdbc.migrator.MigratorSpec.run(MigratorSpec.scala:38)
[info]   at org.scalatest.tools.Framework.org$scalatest$tools$Framework$$runSuite(Framework.scala:321)
[info]   at org.scalatest.tools.Framework$ScalaTestTask.execute(Framework.scala:517)
[info]   at sbt.ForkMain$Run.lambda$runTest$1(ForkMain.java:414)
[info]   at java.base/java.util.concurrent.FutureTask.run(FutureTask.java:264)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
[info]   at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
[info]   at java.base/java.lang.Thread.run(Thread.java:840)
[info]   Cause: org.scalatest.concurrent.ScalaFutures$$anon$1$$anon$2: A timeout occurred waiting for a future to complete. Waited 10000000000 nanoseconds.
[info]   at org.scalatest.concurrent.ScalaFutures$$anon$1.futureValueImpl(ScalaFutures.scala:339)
[info]   at org.scalatest.concurrent.Futures$FutureConcept.futureValue(Futures.scala:476)
[info]   at org.scalatest.concurrent.Futures$FutureConcept.futureValue$(Futures.scala:475)
[info]   at org.scalatest.concurrent.ScalaFutures$$anon$1.futureValue(ScalaFutures.scala:281)
[info]   at org.apache.pekko.persistence.jdbc.migrator.JournalMigratorTest.$anonfun$new$19(JournalMigratorTest.scala:83)
```

What changed

  In all three migrator test cases, the pre-migration assertion (countJournal() == 0) and the migration call (JournalMigrator.migrate()) were moved outside the
  eventually block. Only the post-migration count verification remains inside eventually.

  Before:
  eventually {
    countJournal().futureValue shouldBe 0        // pre-check
    JournalMigrator(...).migrate().futureValue   // migration
    countJournal().futureValue shouldBe 3000     // verify
    // ... more assertions
  } 
  
  After:
```
  countJournal().futureValue shouldBe 0          // pre-check (outside)
  JournalMigrator(...).migrate().futureValue     // migration (outside)
  eventually {
    countJournal().futureValue shouldBe 3000     // verify (retryable)
  } 
  // ... more assertions
```

  Why this fixes it

  The root cause was that if any assertion inside the eventually block failed (e.g., countJournal() or events() timed out on MySQL), the entire block would retry —
  including re-running the migration. But the migration had already completed, so on retry countJournal() == 0 would fail immediately because the data was already
  migrated. This created a cascading failure loop that consumed the entire 10-second PatienceConfig budget.

  By moving the migration outside eventually:
  - The pre-condition check and migration run exactly once
  - Only the post-migration count verification retries (which is the part that genuinely might need retries due to connection pool contention)
  - The event ordering / tag assertions run once after eventually confirms the migration succeeded